### PR TITLE
Add java source code formatting to gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,53 +1,39 @@
 apply plugin: 'idea'
 
-version '1.0.0-SNAPSHOT'
-
 subprojects {
-    apply plugin: 'idea'
-    apply plugin: 'java'
-//    apply plugin: 'checkstyle'
-//    apply plugin: 'findbugs'
-//    apply plugin: 'jacoco'
-//    apply plugin: 'pmd'
+
+    buildscript {
+        repositories {
+            mavenCentral()
+            mavenLocal()
+            jcenter()
+            maven {
+                url "https://plugins.gradle.org/m2/"
+            }
+        }
+
+        dependencies {
+            classpath "org.springframework.boot:spring-boot-gradle-plugin:${version_spring_boot}"
+            classpath "org.asciidoctor:asciidoctor-gradle-plugin:1.5.3"
+            classpath "org.ajoberstar:gradle-git:1.5.1"
+            classpath "com.diffplug.spotless:spotless-plugin-gradle:3.0.0"
+            classpath "com.github.jacobono:gradle-jaxb-plugin:1.3.6"
+        }
+    }
+
+    apply plugin: "idea"
+    apply plugin: "java"
+
+    version "1.0.0-SNAPSHOT"
 
     sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     repositories {
         mavenCentral()
         mavenLocal()
     }
 
-//    findbugs{
-//        sourceSets = [sourceSets.main]
-//        ignoreFailures = true
-//    }
-//
-//    jacocoTestReport{
-//        reports{
-//            xml{
-//                enabled true
-//            }
-//            html{
-//                enabled true
-//            }
-//        }
-//    }
-//
-//    checkstyle {
-//        toolVersion = '7.0'
-//    }
-
-}
-// this task has been automatically added by coderadar to access all JAR dependencies for bytecode analysis
-task printClasspathForCoderadar {
-    doLast {
-        configurations.testRuntime.each { println it }
-    }
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '3.1'
-    distributionType = Wrapper.DistributionType.ALL
 }
 
 idea {

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ subprojects {
 
     buildscript {
         repositories {
-            mavenCentral()
             mavenLocal()
+            mavenCentral()
             jcenter()
             maven {
                 url "https://plugins.gradle.org/m2/"

--- a/plugins/analyzer-plugin-api/build.gradle
+++ b/plugins/analyzer-plugin-api/build.gradle
@@ -1,3 +1,12 @@
+apply plugin: "com.diffplug.gradle.spotless"
+
+spotless {
+    java {
+        googleJavaFormat()
+        paddedCell()
+    }
+}
+
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }

--- a/plugins/checkstyle-analyzer-plugin/build.gradle
+++ b/plugins/checkstyle-analyzer-plugin/build.gradle
@@ -1,3 +1,12 @@
+apply plugin: "com.diffplug.gradle.spotless"
+
+spotless {
+    java {
+        googleJavaFormat()
+        paddedCell()
+    }
+}
+
 dependencies {
     compile project(':plugins:analyzer-plugin-api')
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'

--- a/plugins/findbugs-adapter-plugin/build.gradle
+++ b/plugins/findbugs-adapter-plugin/build.gradle
@@ -1,15 +1,12 @@
-buildscript {
-    repositories {
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "com.github.jacobono:gradle-jaxb-plugin:1.3.6"
+apply plugin: "com.github.jacobono.jaxb"
+apply plugin: "com.diffplug.gradle.spotless"
+
+spotless {
+    java {
+        googleJavaFormat()
+        paddedCell()
     }
 }
-
-apply plugin: 'com.github.jacobono.jaxb'
 
 ext {
     generatedSource = 'src/gen/java'

--- a/plugins/loc-analyzer-plugin/build.gradle
+++ b/plugins/loc-analyzer-plugin/build.gradle
@@ -1,3 +1,12 @@
+apply plugin: "com.diffplug.gradle.spotless"
+
+spotless {
+    java {
+        googleJavaFormat()
+        paddedCell()
+    }
+}
+
 dependencies {
     compile project(':plugins:analyzer-plugin-api')
     testCompile group: 'commons-io', name: 'commons-io', version: '2.4'

--- a/plugins/todo-analyzer-plugin/build.gradle
+++ b/plugins/todo-analyzer-plugin/build.gradle
@@ -1,3 +1,12 @@
+apply plugin: "com.diffplug.gradle.spotless"
+
+spotless {
+    java {
+        googleJavaFormat()
+        paddedCell()
+    }
+}
+
 dependencies {
     compile project(':plugins:analyzer-plugin-api')
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'

--- a/server/coderadar-webapp/build.gradle
+++ b/server/coderadar-webapp/build.gradle
@@ -113,6 +113,10 @@ dependencies {
 
 }
 
+springBoot {
+    executable = true
+}
+
 bootRun {
     jvmArgs =
             [

--- a/server/coderadar-webapp/build.gradle
+++ b/server/coderadar-webapp/build.gradle
@@ -2,33 +2,20 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 import java.text.SimpleDateFormat
 
-buildscript {
-    repositories {
-        mavenCentral()
-        mavenLocal()
-        jcenter()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-
-    dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:${version_spring_boot}")
-        classpath "org.asciidoctor:asciidoctor-gradle-plugin:1.5.3"
-        classpath "org.ajoberstar:gradle-git:1.5.1"
-    }
-}
-
-apply plugin: "java"
 apply plugin: "org.springframework.boot"
 apply plugin: "org.asciidoctor.convert"
 apply plugin: "org.ajoberstar.github-pages"
-
-group = "org.wickedsource"
-version = "1.0.0-SNAPSHOT"
+apply plugin: "com.diffplug.gradle.spotless"
 
 ext {
     snippetsDir = file("build/generated-snippets")
+}
+
+spotless {
+    java {
+        googleJavaFormat()
+        paddedCell()
+    }
 }
 
 processResources {


### PR DESCRIPTION
This PR should be merged at a time where the least possible amount of people are currently working on a Pull Request to be able to format all files and commit them.

This PR breaks the build! You have to call "gradlew spotlessApply" to format all files and then check them all in at once to have a clean code base.