### PR TITLE
Removed HATEOAS references from docs and automated the publishing to gh-pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ stages:
 - name: build
 
 - name: publish_gh
-  if: branch = ascii-docs AND type IN (push)
+  if: branch = master AND type IN (push)
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ jobs:
     script: "./gradlew --stacktrace build"
 
   - stage: publish_gh
-    script:
-   - "cd coderadar-server/coderadar-core"
-   - "../../gradlew --console=plain clean preparePages"
-   - "../../gradlew gitPublishPush --stacktrace"
+    script: "cd coderadar-server/coderadar-core && ../../gradlew --console=plain clean preparePages && ../../gradlew gitPublishPush --stacktrace"
 #   - "../../gradlew bintrayUpload --stacktrace"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ stages:
 
 - name: build
 
-#- name: release
-#  if: branch = master AND type IN (push)
+- name: publish_gh
+  if: branch = ascii-docs AND type IN (push)
 
 jobs:
   include:
@@ -20,10 +20,10 @@ jobs:
   - stage: build
     script: "./gradlew --stacktrace build"
 
-#  - stage: release
-#    script:
-#   - "cd coderadar-server/coderadar-core"
-#   - "../../gradlew --console=plain clean preparePages"
-#   - "../../gradlew gitPublishPush --stacktrace"
+  - stage: publish_gh
+    script:
+   - "cd coderadar-server/coderadar-core"
+   - "../../gradlew --console=plain clean preparePages"
+   - "../../gradlew gitPublishPush --stacktrace"
 #   - "../../gradlew bintrayUpload --stacktrace"
 

--- a/coderadar-server/coderadar-core/build.gradle
+++ b/coderadar-server/coderadar-core/build.gradle
@@ -16,6 +16,7 @@ ext {
 sourceSets{
     test {
         java {
+            gitPublishPush
             srcDir "src/test/performance"
         }
     }

--- a/coderadar-server/coderadar-core/src/main/asciidoc/restapi.adoc
+++ b/coderadar-server/coderadar-core/src/main/asciidoc/restapi.adoc
@@ -85,9 +85,6 @@ To access the functionality of coderadar you have to register a user.
 You need to define a username and a password. The password will be sent as
 plain text and hashed on server side for persisting.
 
-==== Hypermedia links
-include::{snippets}/user/registration/links.adoc[]
-
 ==== Registering a User
 
 ===== Registration Data Structure
@@ -220,10 +217,6 @@ and its sub-resources you provide coderadar with the information it needs to ana
 
 include::{snippets}/projects/create/request-fields.adoc[]
 
-==== Hypermedia Links
-
-include::{snippets}/projects/create/links.adoc[]
-
 ==== Listing Projects
 
 ===== Example Request
@@ -278,10 +271,6 @@ files in all commits have to be updated during these operations.
 ==== Structure
 
 include::{snippets}/modules/create/request-fields.adoc[]
-
-==== Hypermedia Links
-
-include::{snippets}/modules/create/links.adoc[]
 
 ==== Creating a Module
 
@@ -339,10 +328,6 @@ If a project has no file patterns defined, no files will be analyzed.
 
 include::{snippets}/filepatterns/create-update/request-fields.adoc[]
 
-==== Hypermedia Links
-
-include::{snippets}/filepatterns/create-update/links.adoc[]
-
 ==== Listing a Project's File Patterns
 
 ===== Example Request
@@ -376,10 +361,6 @@ plugin via the AnalyzerConfiguration resource.
 ==== Structure
 
 include::{snippets}/analyzerConfiguration/post/request-fields.adoc[]
-
-==== Hypermedia Links
-
-include::{snippets}/analyzerConfiguration/post/links.adoc[]
 
 ==== Adding an Analyzer Configuration
 anchor:create-analyzer[]
@@ -477,10 +458,6 @@ Job is set to inactive.
 
 include::{snippets}/analyzing-job/create-update/request-fields.adoc[]
 
-==== Hypermedia Links
-
-include::{snippets}/analyzing-job/create-update/links.adoc[]
-
 ==== Starting an Analyzing Job
 anchor:creating-analyzing-job[]
 
@@ -513,10 +490,6 @@ part of the quality profile and thus are most important to you.
 ==== Structure
 
 include::{snippets}/qualityprofiles/create/request-fields.adoc[]
-
-==== Hypermedia Links
-
-include::{snippets}/qualityprofiles/create/links.adoc[]
 
 ==== Creating a Quality Profile
 
@@ -625,9 +598,6 @@ are available.
 
 ==== Structure
 include::{snippets}/commit/list/response-fields.adoc[]
-
-==== Hypermedia Links
-include::{snippets}/commit/list/links.adoc[]
 
 ==== Listing a Project's Commits
 

--- a/coderadar-server/coderadar-core/src/test/java/org/wickedsource/coderadar/analyzerconfig/rest/AnalyzerConfigurationControllerTest.java
+++ b/coderadar-server/coderadar-core/src/test/java/org/wickedsource/coderadar/analyzerconfig/rest/AnalyzerConfigurationControllerTest.java
@@ -38,7 +38,10 @@ public class AnalyzerConfigurationControllerTest extends ControllerTestTemplate 
             document(
                 "analyzerConfiguration/post",
                 requestFields(
-                    fields.withPath("id").description("id of the AnalyzerConfiguration"),
+                    fields
+                        .withPath("id")
+                        .description("id of the AnalyzerConfiguration")
+                        .type("Long"),
                     fields
                         .withPath("analyzerName")
                         .description(

--- a/coderadar-server/coderadar-core/src/test/java/org/wickedsource/coderadar/module/rest/ModuleControllerTest.java
+++ b/coderadar-server/coderadar-core/src/test/java/org/wickedsource/coderadar/module/rest/ModuleControllerTest.java
@@ -38,7 +38,7 @@ public class ModuleControllerTest extends ControllerTestTemplate {
             document(
                 "modules/create",
                 requestFields(
-                    fields.withPath("id").description("The id of the module."),
+                    fields.withPath("id").description("The id of the module.").type("Long"),
                     fields
                         .withPath("modulePath")
                         .description(

--- a/coderadar-server/coderadar-core/src/test/java/org/wickedsource/coderadar/project/rest/ProjectControllerTest.java
+++ b/coderadar-server/coderadar-core/src/test/java/org/wickedsource/coderadar/project/rest/ProjectControllerTest.java
@@ -57,7 +57,7 @@ public class ProjectControllerTest extends ControllerTestTemplate {
     return document(
         "projects/create",
         requestFields(
-            fields.withPath("id").description("The id of the project."),
+            fields.withPath("id").description("The id of the project.").type("Long"),
             fields.withPath("name").description("The name of the project to be analyzed."),
             fields
                 .withPath("vcsUrl")

--- a/coderadar-server/coderadar-core/src/test/java/org/wickedsource/coderadar/qualityprofile/QualityProfileControllerTest.java
+++ b/coderadar-server/coderadar-core/src/test/java/org/wickedsource/coderadar/qualityprofile/QualityProfileControllerTest.java
@@ -42,7 +42,7 @@ public class QualityProfileControllerTest extends ControllerTestTemplate {
             document(
                 "qualityprofiles/create",
                 requestFields(
-                    fields.withPath("id").description("The id of the profile."),
+                    fields.withPath("id").description("The id of the profile.").type("Long"),
                     fields.withPath("profileName").description("The display name of the profile."),
                     fields
                         .withPath("metrics[].metricName")


### PR DESCRIPTION
Closes issue #247  and #246 

The docs are automatically published to `gh-pages` and can be browsed at https://cdn.rawgit.com/reflectoring/coderadar/gh-pages/current/docs/restapi.html 
(Already contains the newest version)

All docs are pushed to `current/docs` on `gh-pages`.
