### PR TITLE
Check to see if a project with the same name exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
   apt:
     packages:
     - oracle-java8-installer
-    - oracle-java8-set-default
 
 stages:
 

--- a/coderadar-app/package-lock.json
+++ b/coderadar-app/package-lock.json
@@ -3689,7 +3689,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4104,7 +4105,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4160,6 +4162,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4203,12 +4206,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/coderadar-app/src/app/view/edit-project/edit-project.component.ts
+++ b/coderadar-app/src/app/view/edit-project/edit-project.component.ts
@@ -16,10 +16,6 @@ export class EditProjectComponent implements OnInit {
 
   projectName: string;
 
-  // I need all project at the moment,
-  // because coderadar does not check if the project name exists already
-  projects: Project[] = [];
-
   project: Project;
 
   // Error fields
@@ -35,7 +31,6 @@ export class EditProjectComponent implements OnInit {
 
 
   ngOnInit(): void {
-    this.getProjects();
     this.route.params.subscribe(params => {
       this.projectId = params.id;
       this.getProject();
@@ -98,8 +93,6 @@ export class EditProjectComponent implements OnInit {
   private validateInput(): boolean {
     this.incorrectURL = this.project.vcsUrl.trim().length === 0;
     this.nameEmpty = this.project.name.trim().length === 0;
-    this.projectExists = this.projects.filter(p => (p.name === this.project.name) && p.name !== this.projectName).length !== 0;
-
 
     if (this.project.startDate === 'first commit') {
       this.project.startDate = null;
@@ -109,24 +102,6 @@ export class EditProjectComponent implements OnInit {
       this.project.endDate = null;
     }
 
-    return this.nameEmpty || this.incorrectURL || this.projectExists;
-  }
-
-
-  /**
-   * Gets all projects from the project service and constructs a new array of Project objects
-   * from the returned JSON. Sends a refresh token if access is denied.
-   */
-  private getProjects(): void {
-    this.projectService.getProjects()
-      .then(response => response.body.forEach(project => {
-        const newProject = new Project(project);
-        this.projects.push(newProject);
-      }))
-      .catch(e => {
-        if (e.status && e.status === FORBIDDEN) {
-          this.userService.refresh().then(() => this.getProjects());
-        }
-      });
+    return this.nameEmpty || this.incorrectURL;
   }
 }

--- a/coderadar-server/coderadar-core/src/main/java/org/wickedsource/coderadar/project/rest/ProjectController.java
+++ b/coderadar-server/coderadar-core/src/main/java/org/wickedsource/coderadar/project/rest/ProjectController.java
@@ -82,6 +82,13 @@ public class ProjectController {
   public ResponseEntity<ProjectResource> updateProject(
       @Valid @RequestBody ProjectResource projectResource, @PathVariable Long id) {
     Project project = projectVerifier.loadProjectOrThrowException(id);
+    if (projectRepository.countByName(projectResource.getName()) > 0
+        && !project.getName().equals(projectResource.getName())) {
+      throw new UserException(
+          String.format(
+              "Project with name '%s' already exists. Please choose another name.",
+              projectResource.getName()));
+    }
     project = projectAssembler.updateEntity(projectResource, project);
     Project savedProject = projectRepository.save(project);
     ProjectResource resultResource = projectAssembler.toResource(savedProject);

--- a/coderadar-server/coderadar-core/src/test/java/org/wickedsource/coderadar/project/rest/ProjectControllerTest.java
+++ b/coderadar-server/coderadar-core/src/test/java/org/wickedsource/coderadar/project/rest/ProjectControllerTest.java
@@ -15,6 +15,7 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.ExpectedDatabase;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -135,6 +136,26 @@ public class ProjectControllerTest extends ControllerTestTemplate {
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(containsResource(ProjectResource.class))
+        .andDo(document("projects/update"));
+  }
+
+  @Test
+  @DatabaseSetup(PROJECT_LIST)
+  @ExpectedDatabase(PROJECT_LIST)
+  public void updateProjectWhenNameExistsFails() throws Exception {
+    ProjectResource projectResource = projectResource().validProjectResource2();
+    mvc()
+        .perform(
+            post("/projects/1")
+                .content(toJson(projectResource))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().is(500))
+        .andExpect(
+            result -> {
+              Assertions.assertEquals(
+                  "{\"errorMessage\":\"Project with name 'name2' already exists. Please choose another name.\"}",
+                  result.getResponse().getContentAsString());
+            })
         .andDo(document("projects/update"));
   }
 


### PR DESCRIPTION
Fixes issue #231 

POST requests to `/projects/{id}` previously didn't check if the  project name is already taken by another project.