### PR TITLE
Fix Issues on Testing in TreeTest

### DIFF
--- a/coderadar-dependency-map/src/main/java/io/reflectoring/coderadar/dependencymap/adapter/DependencyTreeAdapter.java
+++ b/coderadar-dependency-map/src/main/java/io/reflectoring/coderadar/dependencymap/adapter/DependencyTreeAdapter.java
@@ -135,9 +135,7 @@ public class DependencyTreeAdapter implements GetDependencyTreePort {
       javaAnalyzer
           .getValidImports(new String(commitContents.get(node.getPath())))
           .forEach(
-              importString ->
-                  getNodeFromImport(importString)
-                      .forEach(node::addToDependencies));
+              importString -> getNodeFromImport(importString).forEach(node::addToDependencies));
     }
   }
 

--- a/coderadar-dependency-map/src/main/java/io/reflectoring/coderadar/dependencymap/adapter/DependencyTreeAdapter.java
+++ b/coderadar-dependency-map/src/main/java/io/reflectoring/coderadar/dependencymap/adapter/DependencyTreeAdapter.java
@@ -134,11 +134,9 @@ public class DependencyTreeAdapter implements GetDependencyTreePort {
     } else {
       javaAnalyzer
           .getValidImports(new String(commitContents.get(node.getPath())))
-          .parallelStream()
           .forEach(
               importString ->
                   getNodeFromImport(importString)
-                      .parallelStream()
                       .forEach(node::addToDependencies));
     }
   }


### PR DESCRIPTION
* Removed parallel stream which seems to have caused the issues (The same class was added as a dependency multiple times, which shouldn't be possible due to add method filtering but seems to be a side effect of parallel stream)