### PR TITLE
Adjust test for more meaningful rest-api-docs

### DIFF
--- a/coderadar-test/src/test/java/io/reflectoring/coderadar/rest/query/GetAvailableMetricsInProjectControllerTest.java
+++ b/coderadar-test/src/test/java/io/reflectoring/coderadar/rest/query/GetAvailableMetricsInProjectControllerTest.java
@@ -61,7 +61,6 @@ class GetAvailableMetricsInProjectControllerTest extends ControllerTestTemplate 
         mvc()
             .perform(
                 get("/projects/" + projectId + "/metrics").contentType(MediaType.APPLICATION_JSON))
-            .andDo(document("metrics/list"))
             .andReturn();
 
     List<String> metrics =
@@ -90,6 +89,7 @@ class GetAvailableMetricsInProjectControllerTest extends ControllerTestTemplate 
         mvc()
             .perform(
                 get("/projects/" + projectId + "/metrics").contentType(MediaType.APPLICATION_JSON))
+            .andDo(document("metrics/list"))
             .andReturn();
 
     List<String> metrics =


### PR DESCRIPTION
Trigger rest-api documentation when there are actually some values to show. Before, nothing was shown.